### PR TITLE
replace email as username with extension ID

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {"filled_form":[["OG","Group ID #","","f",1,""],
-["extensionId","Extension ID","","f",1,""],
+["extensionId","Email as Username","","f",1,""],
 ["url","Page URL","","f",0,"field_page_url"],
 ["pageTitle","Page Title ( <title> ) - Not Saved","","f",0,"field_title"],
 ["pageArticle","Article Title ( <H1> ) - Saved. Fix if needed","","f",0,"title"],

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {"filled_form":[["OG","Group ID #","","f",1,""],
-["username","Email Address as User Name","","f",1,""],
+["extensionId","Extension ID","","f",1,""],
 ["url","Page URL","","f",0,"field_page_url"],
 ["pageTitle","Page Title ( <title> ) - Not Saved","","f",0,"field_title"],
 ["pageArticle","Article Title ( <H1> ) - Saved. Fix if needed","","f",0,"title"],

--- a/content.js
+++ b/content.js
@@ -171,7 +171,7 @@ function sendToServer(obj) {
   promiseToken.then(function(result) {
     var promiseUser = new Promise(function(resolve, reject) {
     var getUser = new XMLHttpRequest();
-	  var uurl = "https://www.fakenewsfitness.org/user.json?mail="+obj.username.value;
+	  var uurl = "https://www.fakenewsfitness.org/user.json?field_extension_id="+obj.extensionId.value;
 	  getUser.onload = function () {
 		  var uStatus = getUser.status;
 		  var uData = JSON.parse(getUser.response);


### PR DESCRIPTION
Hello!

Here is the branch that uses the custom field "extension ID" rather than "email as username" to identify the user.

Try it out, the 'administer users' permission is already turned off on fakenewsfitness.org.

The extension ID field automatically populates when a user is created (or saved), if the field was empty, via rules.

The one thing I haven't done yet is make that field non-editable for those users. I tried custom field permissions but was having trouble getting them to be able to view the field anywhere even though they had view permissions. Thoughts?
