### PR TITLE
Added new branch for Ad Ratio Slider

### DIFF
--- a/config-full.json
+++ b/config-full.json
@@ -1,0 +1,32 @@
+{"filled_form":[["OG","Group ID #","","f",1,""],
+["extensionId","Email as Username","","f",1,""],
+["pageArticle","Article Title ( <H1> ) - Fix to match headline","","f",0,"title"],
+["pageTitle","HTML Page Title ( <title> ) ","","f",0,"field_title"],
+["url","Page URL","","f",0,"field_page_url"],
+["dn","Domain Name","","f",0,"field_domain_name"],
+["tld","Top Level Domain ( TLD )","","f",0,"field_top_level_domain"],
+["modifiedDate","Posted or Modified Date","","f",0,"field_page_last_modified"],
+["allLinks","Page Links - Remove non-sources.","","vl",0,"field_source_links"],
+["aboutLinks","About Us Link","","f",0,"field_about_us_link"],
+["whois","WHOIS Lookup","","v",0,""]
+],
+"critical_thinking":[["FNaboutussummary","About Us Summary","field_about_us_summary"],
+["FNtrustmarkers","Trust Markers","field_trust_markers"],
+["FNmistrustmarkers","Mistrust Markers & Red Flags","field_mistrust_markers"],
+["trustRank","Trust Rank ( Click one )","","s5",1,"field_trust_rank"],
+["FNassessment","Assessment Notes: Why the rank?","body"],
+["FNquestions","Questions (for Comments)","field_questions_"]
+],
+"blank_form":[["username","Email Address as User Name","","f",1,""],
+["OG","Group ID #","","f",0,""],
+["url","Page URL","","f",0,"field_page_url"],
+["pageTitle","Page Title ( <title> )", "","f",0,"field_title"],
+["pageArticle","Article Title (First <H1>)","","f",0,"title"],
+["dn","Domain Name","","f",1,"field_domain_name"],
+["tld","Top Level Domain","","f",0,"field_top_level_domain"],
+["modifiedDate","Modified Date(s)","","f",0,"field_page_last_modified"],
+["allLinks","Page Links","","a",0,"field_source_links"],
+["aboutLinks","About Link(s)","","f",0,"field_about_us_link"]
+],
+"typeAndOG":[{"type":"page_check"},{"groupID":1}]
+}

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-	"filled_form":[
+	"filled_form_page_1":[
 		["OG","Group ID #","","f",1,""],
 		["extensionId","Email as Username","","f",1,""],
 		["pageArticle","Headline ( First <H1> ) - Paste headline here!"	,"","f",0,"title"],
@@ -15,23 +15,27 @@
 		["allLinks","Page Links - remove non-sources"					,"","vl",0,"field_source_links"],
 		["trustRank","Initial Trust Rank ( Click one )"					,"","s5",1,"field_trust_rank"]
 	],
-	"critical_thinking":[
+	"filled_form_page_2":[
 		["FNtrustmarkers","Page Trust Markers","field_trust_markers"],
 		["FNmistrustmarkers","Page Mistrust Markers & Red Flags","field_mistrust_markers"],
 		["FNassessment","Assessment Notes: Why this rank?","body"],
 		["FNquestions","Initial Questions (for Comments)","field_questions_"]
 		],
 	"blank_form":[
-		["username","Email Address as User Name","","f",1,""],
-		["OG","Group ID #","","f",0,""],
-		["url","Page URL","","f",0,"field_page_url"],
-		["pageTitle","Page Title ( <title> )", "","f",0,"field_title"],
-		["pageArticle","Article Title (First <H1>)","","f",0,"title"],
-		["dn","Domain Name","","f",1,"field_domain_name"],
-		["tld","Top Level Domain","","f",0,"field_top_level_domain"],
-		["modifiedDate","Modified Date(s)","","f",0,"field_page_last_modified"],
-		["allLinks","Page Links","","a",0,"field_source_links"],
-		["aboutLinks","About Link(s)","","f",0,"field_about_us_link"]
+		["OG","Group ID #"												,"","f",1,""],
+		["extensionId"													,"Email as Username","","f",1,""],
+		["pageArticle","Headline ( First <H1> ) - Paste headline here!"	,"","f",0,"title"],
+		["pageTitle","Page Title ( <title> ) - Could be headline?"		,"","f",0,"field_title"],
+		["articleAuthor","Article Author"								,"","f",0,"field_article_author"],
+		["modifiedDate","Dateline or Posted/Modified Date"				,"","f",0,"field_page_last_modified"],
+		["adContent","Advertising / Content Ratio ( Click one )"		,"","s51",1,"field_ad_content"],
+		["url","Page URL"												,"","f",0,"field_page_url"],
+		["dn","Domain Name"												,"","f",0,"field_domain_name"],
+		["tld","Top Level Domain ( TLD )"								,"","f",0,"field_top_level_domain"],
+		["aboutLinks","About Us Link"									,"","f",0,"field_about_us_link"],
+		["whois","WHOIS Lookup"											,"","v",0,""],
+		["allLinks","Page Links - remove non-sources"					,"","vl",0,"field_source_links"],
+		["trustRank","Initial Trust Rank ( Click one )"					,"","s5",1,"field_trust_rank"]
 		],
 	"typeAndOG":[
 		{"type":"page_check"},{"groupID":1}

--- a/config.json
+++ b/config.json
@@ -1,34 +1,38 @@
-{"filled_form":[["OG","Group ID #","","f",1,""],
-["extensionId","Email as Username","","f",1,""],
-["url","Page URL","","f",0,"field_page_url"],
-["pageTitle","Page Title ( <title> ) - Not Saved","","f",0,"field_title"],
-["pageArticle","Article Title ( <H1> ) - Saved. Fix if needed","","f",0,"title"],
-["dn","Domain Name","","f",0,"field_domain_name"],
-["tld","Top Level Domain ( TLD )","","f",0,"field_top_level_domain"],
-["params","URL Parameters","","f",0,""],
-["modifiedDate","Posted or Modified Date","","f",0,"field_page_last_modified"],
-["allLinks","Page Links - Remove non-sources.","","vl",0,"field_source_links"],
-["aboutLinks","About Link(s)","","f",0,"field_about_us_link"],
-["whois","WHOIS Lookup","","v",0,""],
-["trustRank","Trust Rank ( Click one )","","s5",1,"field_trust_rank"]
-],
-"critical_thinking":[["FNaboutussummary","About Us Summary","field_about_us_summary"],
-["FNtrustmarkers","Trust Markers","field_trust_markers"],
-["FNmistrustmarkers","Mistrust Markers","field_mistrust_markers"],
-["FNassessment","Assessment","body"],
-["FNquestions","Questions","field_questions_"]
-],
-"blank_form":[["username","Email Address as User Name","","f",1,""],
-["OG","Group ID #","","f",0,""],
-["url","Page URL","","f",0,"field_page_url"],
-["pageTitle","Page Title ( <title> )", "","f",0,"field_title"],
-["pageArticle","Article Title (First <H1>)","","f",0,"title"],
-["dn","Domain Name","","f",1,"field_domain_name"],
-["tld","Top Level Domain","","f",0,"field_top_level_domain"],
-["params","URL Parameters","","f",0,""],
-["modifiedDate","Modified Date(s)","","f",0,"field_page_last_modified"],
-["allLinks","Page Links","","a",0,"field_source_links"],
-["aboutLinks","About Link(s)","","f",0,"field_about_us_link"]
-],
-"typeAndOG":[{"type":"page_check"},{"groupID":1}]
+{
+	"filled_form":[
+		["OG","Group ID #","","f",1,""],
+		["extensionId","Email as Username","","f",1,""],
+		["pageArticle","Article Title ( <H1> ) - Fix to match headline"	,"","f",0,"title"],
+		["pageTitle","HTML Page Title ( <title> )"						,"","f",0,"field_title"],
+		["url","Page URL"												,"","f",0,"field_page_url"],
+		["dn","Domain Name"												,"","f",0,"field_domain_name"],
+		["tld","Top Level Domain ( TLD )"								,"","f",0,"field_top_level_domain"],
+		["adContent","Advertising Content ( Click one )"				,"","s51",1,"field_ad_content"],
+		["modifiedDate","Posted or Modified Date"						,"","f",0,"field_page_last_modified"],
+		["allLinks","Page Links - Remove non-sources"					,"","vl",0,"field_source_links"],
+		["aboutLinks","About Us Link"									,"","f",0,"field_about_us_link"],
+		["whois","WHOIS Lookup"											,"","v",0,""],
+		["trustRank","Initial Trust Rank ( Click one )"					,"","s5",1,"field_trust_rank"]
+	],
+	"critical_thinking":[
+		["FNtrustmarkers","Page Trust Markers","field_trust_markers"],
+		["FNmistrustmarkers","Page Mistrust Markers & Red Flags","field_mistrust_markers"],
+		["FNassessment","Assessment Notes: Why this rank?","body"],
+		["FNquestions","Initial Questions (for Comments)","field_questions_"]
+		],
+	"blank_form":[
+		["username","Email Address as User Name","","f",1,""],
+		["OG","Group ID #","","f",0,""],
+		["url","Page URL","","f",0,"field_page_url"],
+		["pageTitle","Page Title ( <title> )", "","f",0,"field_title"],
+		["pageArticle","Article Title (First <H1>)","","f",0,"title"],
+		["dn","Domain Name","","f",1,"field_domain_name"],
+		["tld","Top Level Domain","","f",0,"field_top_level_domain"],
+		["modifiedDate","Modified Date(s)","","f",0,"field_page_last_modified"],
+		["allLinks","Page Links","","a",0,"field_source_links"],
+		["aboutLinks","About Link(s)","","f",0,"field_about_us_link"]
+		],
+	"typeAndOG":[
+		{"type":"page_check"},{"groupID":1}
+	]
 }

--- a/config.json
+++ b/config.json
@@ -2,16 +2,17 @@
 	"filled_form":[
 		["OG","Group ID #","","f",1,""],
 		["extensionId","Email as Username","","f",1,""],
-		["pageArticle","Article Title ( <H1> ) - Fix to match headline"	,"","f",0,"title"],
-		["pageTitle","HTML Page Title ( <title> )"						,"","f",0,"field_title"],
+		["pageArticle","Headline ( First <H1> ) - Paste headline here!"	,"","f",0,"title"],
+		["pageTitle","Page Title ( <title> ) - Could be headline?"		,"","f",0,"field_title"],
+		["articleAuthor","Article Author"								,"","f",0,"field_article_author"],
+		["modifiedDate","Dateline or Posted/Modified Date"				,"","f",0,"field_page_last_modified"],
+		["adContent","Advertising / Content Ratio ( Click one )"		,"","s51",1,"field_ad_content"],
 		["url","Page URL"												,"","f",0,"field_page_url"],
 		["dn","Domain Name"												,"","f",0,"field_domain_name"],
 		["tld","Top Level Domain ( TLD )"								,"","f",0,"field_top_level_domain"],
-		["adContent","Advertising Content ( Click one )"				,"","s51",1,"field_ad_content"],
-		["modifiedDate","Posted or Modified Date"						,"","f",0,"field_page_last_modified"],
-		["allLinks","Page Links - Remove non-sources"					,"","vl",0,"field_source_links"],
 		["aboutLinks","About Us Link"									,"","f",0,"field_about_us_link"],
 		["whois","WHOIS Lookup"											,"","v",0,""],
+		["allLinks","Page Links - remove non-sources"					,"","vl",0,"field_source_links"],
 		["trustRank","Initial Trust Rank ( Click one )"					,"","s5",1,"field_trust_rank"]
 	],
 	"critical_thinking":[

--- a/content.js
+++ b/content.js
@@ -263,51 +263,51 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
         // Process URL here so we only run controller function once
 		var thisURL = controller.getURL();
 		// Add vars to form array from config, for auto-fill. Default is "". This way we can configure new fields that don't autofill in any order
-		var configMax = msg.config.filled_form.length;
+		var configMax = msg.config.filled_form_page_1.length;
 		for (var i = 1; i < configMax; i++) {
-			switch (msg.config.filled_form[i][0]) {
+			switch (msg.config.filled_form_page_1[i][0]) {
 				case "url":
-				  msg.config.filled_form[i][2] = thisURL[0];
+				  msg.config.filled_form_page_1[i][2] = thisURL[0];
 				  break;
 				case "pageTitle":
-				  msg.config.filled_form[i][2] = controller.getTitle();
+				  msg.config.filled_form_page_1[i][2] = controller.getTitle();
 				  break;
 				case "pageArticle":
-				  msg.config.filled_form[i][2] = controller.getArticle();
+				  msg.config.filled_form_page_1[i][2] = controller.getArticle();
 				  break;
 				case "dn":
-				  msg.config.filled_form[i][2] = controller.domainFinder();
+				  msg.config.filled_form_page_1[i][2] = controller.domainFinder();
 				  break;
 				case "tld":
-				  msg.config.filled_form[i][2] = controller.tldParser();
+				  msg.config.filled_form_page_1[i][2] = controller.tldParser();
 				  break;
 				case "params":
-				  msg.config.filled_form[i][2] = thisURL[1];
+				  msg.config.filled_form_page_1[i][2] = thisURL[1];
 				  break;
 				case "modifiedDate":
-				  msg.config.filled_form[i][2] = controller.dateFinder();
+				  msg.config.filled_form_page_1[i][2] = controller.dateFinder();
 				  break;
 				case "allLinks":
-				  msg.config.filled_form[i][2] = controller.linkFinder();
+				  msg.config.filled_form_page_1[i][2] = controller.linkFinder();
 				  break;
 				case "aboutLinks":
-				  msg.config.filled_form[i][2] = controller.aboutFinder();
+				  msg.config.filled_form_page_1[i][2] = controller.aboutFinder();
 				  break;
 				case "whois":
-				  msg.config.filled_form[i][2] = whoIsArr;
+				  msg.config.filled_form_page_1[i][2] = whoIsArr;
 				  break;
 				default:
-				  msg.config.filled_form[i][2] = ""
+				  msg.config.filled_form_page_1[i][2] = ""
 			}
 		}
 
         //Build the form
-        makeForm(msg.config.filled_form, msg.config.critical_thinking, msg.config.typeAndOG);
+        makeForm(msg.config.filled_form_page_1, msg.config.filled_form_page_2, msg.config.typeAndOG);
 
     }
     else if (msg.text === 'build_form_blank') {
         //Build the form
-        makeForm(msg.config.blank_form, msg.config.critical_thinking, msg.config.typeAndOG);
+        makeForm(msg.config.blank_form, msg.config.filled_form_page_2, msg.config.typeAndOG);
     }
 });
 

--- a/content.js
+++ b/content.js
@@ -97,6 +97,16 @@ function sendToServer(obj) {
 				  }
 			  }
             break;
+            case "adContent":
+              var items = obj.adContent.childNodes;
+			  var itemsLength = items.length;
+			  for (var i = 0; i < itemsLength; i++) {
+				  if (items[i].childNodes[1].checked == true) {
+					  rawData.adContent = {"field_ad_content":parseInt(items[i].childNodes[1].value)};
+					  break;
+				  }
+			  }
+            break;
             // Page Two //
             case "FNassessment":
               rawData.FNassessment = {"body":{"value":obj.FNassessment.value}};
@@ -676,6 +686,28 @@ function makeForm(fields, critFields, config) {
 		 case "s5": // https://codepen.io/Buttonpresser/pen/qiuIx
                 var currentLikert = 0;
                 var values5 = ['1 = Full Mistrust', '2 = Some Mistrust','3 = Cannot Tell','4 = Some Trust','5 = Full Trust']
+                var listNode = document.createElement("UL");
+                    listNode.setAttribute("id", fields[i][0]);
+                    listNode.setAttribute("class", "likert");
+                    for(var x = 0; x < 5; x++){
+                        var listItem = document.createElement("LI");
+                        var inputElement = document.createElement("input"); //input element, text
+                        inputElement.setAttribute('type',"radio");
+                        inputElement.setAttribute('name',"likert");
+                        inputElement.setAttribute('value',x+1);
+                        var labelElement = document.createElement("label");
+                        var labelText = document.createTextNode(values5[x]);
+                        labelElement.appendChild(labelText);
+                        listItem.appendChild(labelElement);
+                        listItem.appendChild(inputElement);
+                        listNode.appendChild(listItem);
+                    }
+                formName.appendChild(listNode);
+                break;
+		/* ELI - Can we vary the values but use the same code for the slider? */
+		case "s51": // https://codepen.io/Buttonpresser/pen/qiuIx
+                var currentLikert = 0;
+                var values5 = ['1 = No Ads', 'Some Ads','3 = Many Ads','4 = Too Many Ads','5 = Way Too Many Ads']
                 var listNode = document.createElement("UL");
                     listNode.setAttribute("id", fields[i][0]);
                     listNode.setAttribute("class", "likert");

--- a/content.js
+++ b/content.js
@@ -62,9 +62,9 @@ function sendToServer(obj) {
 			case "pageArticle":
 			  // Determine which title to submit
 			  var submitTitle = "";
-			  if (obj.pageArticle.value !== "No h1 tags found" && obj.pageArticle.value !== "") {
+			  if (obj.pageArticle.value !== "No <h1> found. Paste Headline here." && obj.pageArticle.value !== "") {
 				submitTitle = obj.pageArticle.value;
-			  } else if (obj.pageTitle.value !== "No title tags found") {
+			  } else if (obj.pageTitle.value !== "No <title> tag found. Not trustworthy.") {
 				submitTitle = obj.pageTitle.value;
 			  } else {
 				submitTitle = "No Title";
@@ -73,6 +73,8 @@ function sendToServer(obj) {
 			  rawData.titlefield = {"title_field":submitTitle};
 			break;
 			case "pageTitle":
+			break;
+			case "articleAuthor":
 			break;
 			case "aboutLinks":
 			  //Check about link for proper URL
@@ -345,7 +347,7 @@ var controller = (function(){
   function getTitle () {
 	  var title = document.getElementsByTagName("title");
 	  if (title.length == 0) {
-		  return "No <title> tag found.";
+		  return "No <title> tag found. Not trustworthy.";
 	  } else {
 		  var treturn = title[0].innerText;
 		  return treturn;
@@ -355,13 +357,12 @@ var controller = (function(){
   function getArticle () {
 	  var article = document.getElementsByTagName("h1")
 	  if (article.length == 0) {
-		  return "No <h1> found. Paste Article Title Here.";
+		  return "No <h1> found. Paste Headline here.";
 	  } else {
 		  var areturn = article[0].innerText;
 		  return areturn;
 	  }
   }
-
   // search document.body for ABOUT US or similar in menu lists
   function aboutFinder () {
 	var aboutItems = document.getElementsByTagName("li");
@@ -707,7 +708,7 @@ function makeForm(fields, critFields, config) {
 		/* ELI - Can we vary the values but use the same code for the slider? */
 		case "s51": // https://codepen.io/Buttonpresser/pen/qiuIx
                 var currentLikert = 0;
-                var values5 = ['1 = No Ads', 'Some Ads','3 = Many Ads','4 = Too Many Ads','5 = Way Too Many Ads']
+                var values5 = ['1 = No Ads', '1-2 Ads','3 = Some Ads','4 = Many Ads','5 = Too Many Ads']
                 var listNode = document.createElement("UL");
                     listNode.setAttribute("id", fields[i][0]);
                     listNode.setAttribute("class", "likert");

--- a/form.css
+++ b/form.css
@@ -114,7 +114,7 @@ body
   list-style:none;
   width:100%;
   margin:0;
-  padding:0 0 35px;
+  padding:0 0 10px 35px;
   display:block;
   /* border-bottom:2px solid #efefef; */
 }

--- a/form.css
+++ b/form.css
@@ -116,7 +116,7 @@ body
   margin:0;
   padding:0 0 35px;
   display:block;
-  border-bottom:2px solid #efefef;
+  /* border-bottom:2px solid #efefef; */
 }
 #FakeNewsForm form .likert:last-of-type {border-bottom:0;}
 


### PR DESCRIPTION
Eli, on line 707 of content.js, I had to duplicate a lot of code (from S5 to S51).  I think it should be possible to create arrays with the Slider Likert values, and then make a function for the slider rendering - we'll want many of these. 

I made an issue for this.  If you can make the mods to the code before pulling, please do; otherwise, this should just work.  It involved a new slider field in Drupal as well as code in the extension that paralleled existing code. 